### PR TITLE
Upgrade SW sync to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12902,9 +12902,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -13469,9 +13469,9 @@
       "dev": true
     },
     "skiller-whale-sync": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/skiller-whale-sync/-/skiller-whale-sync-1.4.0.tgz",
-      "integrity": "sha512-186RqKtbRSOQ1KnOIl2UKkmjNv+RdR7la3Dkz/PrXhvzvMuQPL/4DQPKR4MH6769EeQ9EOtOSFh5AkGSe2RUUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/skiller-whale-sync/-/skiller-whale-sync-1.5.0.tgz",
+      "integrity": "sha512-FZiHd+5kWNg0oYR+WqY0N6JfAP42948TO0Nlxp7najzpf03RDfvPA0VjPiVjEIBkJJ03hUrJd/Yg1C5XWxVMaA==",
       "requires": {
         "concurrently": "^4.1.0",
         "cross-spawn": "^6.0.5"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "react-dom": "^16.9.0",
     "react-redux": "^7.1.3",
     "redux": "^4.0.4",
-    "skiller-whale-sync": "^1.4.0"
+    "skiller-whale-sync": "^1.5.0"
   }
 }


### PR DESCRIPTION
Upgrades `skiller-whale-sync` to `^1.5.0`, plus a bump to `lodash`.
